### PR TITLE
tox: reduce the minimal test coverage expectation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
     pytest
     pytest-cov
 commands =
-    pytest --cov --cov-append --cov-report=term-missing  --cov-fail-under=35 {posargs:tests}
+    pytest --cov --cov-append --cov-report=term-missing  --cov-fail-under=30 {posargs:tests}
 depends =
     {py311}: clean
     report: py31


### PR DESCRIPTION
Move from 35% to 30% for now. This will be revisited lated.